### PR TITLE
chore: add GitHub Actions CI and branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
+      - name: Upload coverage (optional)
+        if: always()
+        run: npm test -- --coverage --coverageDirectory=coverage
+        continue-on-error: true

--- a/CFORGE_DEV.md
+++ b/CFORGE_DEV.md
@@ -21,10 +21,24 @@
 - Conventional commits
 
 ## Existing Modules
-_none yet — updated after each release_
+- SDLCDoctrine — pure domain validation (branch names, PR readiness, release gates)
+- OctokitGitHubClient — GitHub API adapter (milestones, issues, branches, PRs, releases)
+- PlanSprint — PRD → milestone + ordered issues (architecture first)
+- ImplementIssue — issue → branch + contextualized Claude Code prompt
+- VerifyIssue — PR readiness check + critique pass
+- CreateRelease — changelog generation + GitHub release
+- CForgePromptGenerator — OpenRouter-backed prompt generation
+- ChatSession — repo-aware planning session with history
+- RepoStateLoader — parallel GitHub state fetcher
 
 ## Decision Log
-_major architectural decisions recorded here as the project grows_
+- v0.1.0: Clean/Onion Architecture chosen — domain never imports infrastructure
+- v0.1.0: @octokit/rest for GitHub API — clean interface abstraction
+- v0.1.0: gh auth token fallback — no GITHUB_TOKEN required locally
+- v0.2.0: dotenv for local env — .env never committed
+- v0.2.0: RepoState injected into chat system prompt — LLM always has live repo context
+- v0.3.0: GitHub Actions CI on all PRs — cforge-dev verify reads real check results
+- v0.3.0: Branch protection on main — SDLC doctrine enforced at GitHub level
 
 ## Open Questions
 _none yet_


### PR DESCRIPTION
## Summary
Adds GitHub Actions CI workflow that runs on every PR targeting main.

## Changes
- .github/workflows/ci.yml — runs npm ci, build, test on ubuntu-latest
- Branch protection enabled on main (required checks + no force push)
- CFORGE_DEV.md updated with current module list and decision log

## Checklist
- [ ] CI passes on this PR
- [ ] Branch protection active on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)