### PR TITLE
feat: Fix: cforge-dev verify cannot find PR opened by --auto

### DIFF
--- a/src/application/use-cases/VerifyIssue.ts
+++ b/src/application/use-cases/VerifyIssue.ts
@@ -1,9 +1,16 @@
 import { GitHubClient } from "../../domain/interfaces/GitHubClient";
 import { PromptGenerator } from "../../domain/interfaces/PromptGenerator";
-import { Issue } from "../../domain/models/Issue";
+import { Issue, IssueType } from "../../domain/models/Issue";
 import { PullRequest } from "../../domain/models/PullRequest";
 import { SDLCDoctrine } from "../../domain/engines/SDLCDoctrine";
 import { VerifyIssueDto } from "../dtos/VerifyIssueDto";
+
+const BRANCH_PREFIX: Partial<Record<IssueType, string>> = {
+  [IssueType.FEATURE]: "feat/",
+  [IssueType.BUG]: "fix/",
+  [IssueType.TASK]: "chore/",
+  [IssueType.ARCHITECTURE]: "feat/",
+};
 
 export interface VerifyIssueResult {
   issue: Issue;
@@ -29,7 +36,7 @@ export class VerifyIssue {
     const issue = await this.github.getIssue(input.issueNumber);
     const openPRs = await this.github.listOpenPullRequests();
 
-    const pr = openPRs.find((p) => issue.branch && p.branch === issue.branch) ?? null;
+    const pr = this.matchPR(issue, openPRs);
 
     const blockers: string[] = [];
 
@@ -61,5 +68,48 @@ export class VerifyIssue {
     }
 
     return { issue, pr, ready, critique, blockers, nextSteps };
+  }
+
+  private matchPR(issue: Issue, prs: PullRequest[]): PullRequest | null {
+    // Strategy 1: exact match on issue.branch if set
+    if (issue.branch) {
+      const match = prs.find((p) => p.branch === issue.branch);
+      if (match) return match;
+    }
+
+    // Strategy 2: match by computed branch name based on issue type and title
+    const expectedBranch = this.buildExpectedBranchName(issue);
+    if (expectedBranch) {
+      const match = prs.find((p) => p.branch === expectedBranch);
+      if (match) return match;
+    }
+
+    // Strategy 3: fallback — issue number anywhere in branch name
+    const byNumber = prs.find((p) => p.branch.includes(String(issue.number)));
+    if (byNumber) return byNumber;
+
+    // Strategy 4: issue number referenced in PR body (e.g. "Closes #42")
+    const byBody = prs.find((p) => p.body?.includes(`#${issue.number}`));
+    if (byBody) return byBody;
+
+    return null;
+  }
+
+  private buildExpectedBranchName(issue: Issue): string {
+    if (issue.type === IssueType.ARCHITECTURE) {
+      return `feat/architecture-${issue.number}`;
+    }
+
+    const prefix = BRANCH_PREFIX[issue.type];
+    if (!prefix) return "";
+
+    const slug = issue.title
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, "")
+      .replace(/\s+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "");
+
+    return `${prefix}${slug}`;
   }
 }

--- a/src/domain/models/PullRequest.ts
+++ b/src/domain/models/PullRequest.ts
@@ -5,4 +5,5 @@ export interface PullRequest {
   base: string;
   status: "open" | "closed" | "merged";
   checksPassing: boolean;
+  body?: string;
 }

--- a/src/infrastructure/github/OctokitGitHubClient.ts
+++ b/src/infrastructure/github/OctokitGitHubClient.ts
@@ -190,6 +190,7 @@ export class OctokitGitHubClient implements GitHubClient {
       base: base.ref,
       status,
       checksPassing: mergeableState === "clean",
+      body: (data.body as string) ?? undefined,
     };
   }
 }

--- a/tests/application/VerifyIssue.test.ts
+++ b/tests/application/VerifyIssue.test.ts
@@ -36,6 +36,7 @@ function makePR(overrides: Partial<PullRequest> = {}): PullRequest {
     base: "main",
     status: "open",
     checksPassing: true,
+    body: undefined,
     ...overrides,
   };
 }
@@ -197,5 +198,94 @@ describe("VerifyIssue", () => {
     const result = await verify.execute({ issueNumber: 42, context: mockContext });
 
     expect(result.pr?.number).toBe(10);
+  });
+
+  it("should match ARCHITECTURE issue PR by feat/architecture-<number> branch", async () => {
+    const issue = makeIssue({ number: 2, type: IssueType.ARCHITECTURE, title: "Setup architecture", branch: undefined });
+    const archPR = makePR({ branch: "feat/architecture-2", number: 14 });
+    const unrelatedPR = makePR({ branch: "feat/other-thing", number: 99 });
+    const gh = mockGitHubClient(issue, [unrelatedPR, archPR]);
+    const prompt = mockPromptGenerator();
+    const verify = new VerifyIssue(gh, prompt);
+
+    const result = await verify.execute({ issueNumber: 2, context: mockContext });
+
+    expect(result.pr?.number).toBe(14);
+  });
+
+  it("should match FEATURE issue PR by computed slug branch when issue.branch is undefined", async () => {
+    const issue = makeIssue({ number: 5, type: IssueType.FEATURE, title: "Add login", branch: undefined });
+    const matchingPR = makePR({ branch: "feat/add-login", number: 20 });
+    const gh = mockGitHubClient(issue, [matchingPR]);
+    const prompt = mockPromptGenerator();
+    const verify = new VerifyIssue(gh, prompt);
+
+    const result = await verify.execute({ issueNumber: 5, context: mockContext });
+
+    expect(result.pr?.number).toBe(20);
+  });
+
+  it("should match BUG issue PR by fix/ prefixed branch", async () => {
+    const issue = makeIssue({ number: 7, type: IssueType.BUG, title: "Fix crash on login", branch: undefined });
+    const matchingPR = makePR({ branch: "fix/fix-crash-on-login", number: 21 });
+    const unrelatedPR = makePR({ branch: "feat/other", number: 99 });
+    const gh = mockGitHubClient(issue, [unrelatedPR, matchingPR]);
+    const prompt = mockPromptGenerator();
+    const verify = new VerifyIssue(gh, prompt);
+
+    const result = await verify.execute({ issueNumber: 7, context: mockContext });
+
+    expect(result.pr?.number).toBe(21);
+  });
+
+  it("should match TASK issue PR by chore/ prefixed branch", async () => {
+    const issue = makeIssue({ number: 8, type: IssueType.TASK, title: "Update dependencies", branch: undefined });
+    const matchingPR = makePR({ branch: "chore/update-dependencies", number: 22 });
+    const unrelatedPR = makePR({ branch: "feat/other", number: 99 });
+    const gh = mockGitHubClient(issue, [unrelatedPR, matchingPR]);
+    const prompt = mockPromptGenerator();
+    const verify = new VerifyIssue(gh, prompt);
+
+    const result = await verify.execute({ issueNumber: 8, context: mockContext });
+
+    expect(result.pr?.number).toBe(22);
+  });
+
+  it("should use issue number fallback to match PR when branch contains the issue number", async () => {
+    const issue = makeIssue({ number: 42, type: IssueType.FEATURE, title: "Some feature", branch: undefined });
+    const matchingPR = makePR({ branch: "feat/some-unrelated-42", number: 30 });
+    const gh = mockGitHubClient(issue, [matchingPR]);
+    const prompt = mockPromptGenerator();
+    const verify = new VerifyIssue(gh, prompt);
+
+    const result = await verify.execute({ issueNumber: 42, context: mockContext });
+
+    expect(result.pr?.number).toBe(30);
+  });
+
+  it("should match PR by issue number in PR body (Closes #<number>)", async () => {
+    const issue = makeIssue({ number: 42, type: IssueType.FEATURE, title: "Unrelated title xyz", branch: undefined });
+    const matchingPR = makePR({ branch: "feat/completely-different-branch", number: 31, body: "Closes #42" });
+    const gh = mockGitHubClient(issue, [matchingPR]);
+    const prompt = mockPromptGenerator();
+    const verify = new VerifyIssue(gh, prompt);
+
+    const result = await verify.execute({ issueNumber: 42, context: mockContext });
+
+    expect(result.pr?.number).toBe(31);
+  });
+
+  it("should return null pr when no PR matches any strategy", async () => {
+    const issue = makeIssue({ number: 99, type: IssueType.FEATURE, title: "Unmatched feature", branch: undefined });
+    const unrelatedPR = makePR({ branch: "fix/something-else", number: 50, body: "No issue reference" });
+    const gh = mockGitHubClient(issue, [unrelatedPR]);
+    const prompt = mockPromptGenerator();
+    const verify = new VerifyIssue(gh, prompt);
+
+    const result = await verify.execute({ issueNumber: 99, context: mockContext });
+
+    expect(result.pr).toBeNull();
+    expect(result.ready).toBe(false);
+    expect(result.blockers).toContain("No open PR found for this issue");
   });
 });


### PR DESCRIPTION
## Summary
Automated implementation via cforge-dev --auto

Fix: cforge-dev verify cannot find PR opened by --auto

## Issue
Closes #14

## Implementation
Done. Here's a summary of what was implemented:

**Root cause:** `OctokitGitHubClient.mapIssue()` always returns `branch: undefined`, so the old `issue.branch && p.branch === issue.branch` check in `VerifyIssue` never matched any PR.

**Changes:**

- **`src/application/use-cases/VerifyIssue.ts`** — Replaced the single-line branch match with a `matchPR()` method using 4 strategies:
  1. Exact match on `issue.branch` (backward compat)
  2. Computed branch name (`feat/architecture-<n>` for ARCHITEC

## Cost
Claude session cost: $0.9732 (32 turns)