### PR TITLE
feat: Fix: PRs appear in open issues list (GitHub API treats PRs as issues)

### DIFF
--- a/src/infrastructure/github/OctokitGitHubClient.ts
+++ b/src/infrastructure/github/OctokitGitHubClient.ts
@@ -76,7 +76,8 @@ export class OctokitGitHubClient implements GitHubClient {
       milestone: milestoneId as unknown as string,
       state: "all",
     });
-    return data.map((d) => this.mapIssue(d));
+    const filteredIssues = data.filter((item) => !item.pull_request);
+    return filteredIssues.map((d) => this.mapIssue(d));
   }
 
   async createBranch(name: string, fromBranch: string): Promise<void> {

--- a/tests/infrastructure/OctokitGitHubClient.test.ts
+++ b/tests/infrastructure/OctokitGitHubClient.test.ts
@@ -148,6 +148,36 @@ describe("OctokitGitHubClient", () => {
     );
   });
 
+  it("should exclude pull requests from listIssues results", async () => {
+    mockOctokit.issues.listForRepo.mockResolvedValueOnce({
+      data: [
+        {
+          id: 1,
+          number: 1,
+          title: "Real Issue",
+          body: "An actual issue",
+          labels: [{ name: "bug" }],
+          milestone: null,
+        },
+        {
+          id: 2,
+          number: 2,
+          title: "A Pull Request",
+          body: "A PR masquerading as issue",
+          labels: [],
+          milestone: null,
+          pull_request: { url: "https://api.github.com/repos/owner/repo/pulls/2" },
+        },
+      ],
+    });
+
+    const result = await client.listIssues();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].number).toBe(1);
+    expect(result[0].title).toBe("Real Issue");
+  });
+
   it("should create branch by fetching SHA first then creating ref", async () => {
     mockOctokit.git.getRef.mockResolvedValueOnce({
       data: { object: { sha: "abc123" } },


### PR DESCRIPTION
## Summary
Automated implementation via cforge-dev --auto

Fix: PRs appear in open issues list (GitHub API treats PRs as issues)

## Issue
Closes #15

## Implementation
Done. Here's a summary of what was done:

**Changes:**

- `src/infrastructure/github/OctokitGitHubClient.ts` (`listIssues`, line ~79): Added `.filter((item) => !item.pull_request)` before mapping, excluding any items the GitHub API returns that have a `pull_request` field.

- `tests/infrastructure/OctokitGitHubClient.test.ts`: Added a new test `"should exclude pull requests from listIssues results"` that mocks a mixed API response (1 issue + 1 PR) and asserts only the real issue is returned.

Al

## Cost
Claude session cost: $0.3131 (13 turns)