### PR TITLE
feat: Add --version flag to cforge-dev CLI

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@ import { verifyCommand } from "./commands/verify";
 import { releaseCommand } from "./commands/release";
 import { chatCommand } from "./commands/chat";
 import { auditCommand } from "./commands/audit";
+import { getVersion } from "./utils/getVersion";
 
 const USAGE = `cforge-dev — AI-native SDLC orchestrator
 
@@ -25,6 +26,11 @@ async function main(): Promise<void> {
 
   if (!command) {
     console.log(USAGE);
+    process.exit(0);
+  }
+
+  if (command === "--version" || command === "-v") {
+    console.log(getVersion());
     process.exit(0);
   }
 

--- a/src/cli/utils/getVersion.ts
+++ b/src/cli/utils/getVersion.ts
@@ -1,0 +1,8 @@
+import fs from "fs";
+import path from "path";
+
+export function getVersion(): string {
+  const pkgPath = path.resolve(__dirname, "../../../package.json");
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8")) as { version: string };
+  return pkg.version;
+}

--- a/tests/cli/getVersion.test.ts
+++ b/tests/cli/getVersion.test.ts
@@ -1,0 +1,46 @@
+import { getVersion } from "../../src/cli/utils/getVersion";
+import { spawnSync } from "child_process";
+import path from "path";
+
+const ROOT = path.resolve(__dirname, "../..");
+const TSNODE = path.join(ROOT, "node_modules/.bin/ts-node");
+const CLI = path.join(ROOT, "src/cli/index.ts");
+
+describe("getVersion", () => {
+  it("returns a non-empty string", () => {
+    const version = getVersion();
+    expect(typeof version).toBe("string");
+    expect(version.length).toBeGreaterThan(0);
+  });
+
+  it("returns a valid semver version string", () => {
+    const version = getVersion();
+    expect(version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("matches the version field in package.json", () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const pkg = require("../../package.json") as { version: string };
+    expect(getVersion()).toBe(pkg.version);
+  });
+});
+
+describe("CLI version flags", () => {
+  it("outputs version when --version flag is provided", () => {
+    const result = spawnSync(TSNODE, [CLI, "--version"], {
+      cwd: ROOT,
+      encoding: "utf-8",
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("outputs version when -v flag is provided", () => {
+    const result = spawnSync(TSNODE, [CLI, "-v"], {
+      cwd: ROOT,
+      encoding: "utf-8",
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});


### PR DESCRIPTION
## Summary
Automated implementation via cforge-dev --auto

Add --version flag to cforge-dev CLI

## Issue
Closes #22

## Implementation
Done. Here's what was implemented:

- **`src/cli/utils/getVersion.ts`** — pure function reading `version` from `package.json` via `fs.readFileSync` (no Infrastructure imports)
- **`src/cli/index.ts`** — intercepts `--version` / `-v` before the command switch, prints version and exits 0
- **`tests/cli/getVersion.test.ts`** — 3 unit tests for `getVersion()` + 2 integration tests that spawn the CLI via `ts-node` and assert the output

All 133 tests pass (14 suites, including the 5 new ones).

## Cost
Claude session cost: $0.4363 (15 turns)