### PR TITLE
feat: Fix: repo detection from git remote URL

### DIFF
--- a/src/cli/utils/loadContext.ts
+++ b/src/cli/utils/loadContext.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { ProjectContext } from "../../domain/models/ProjectContext";
+import { resolveRepoFromGit } from "./resolveRepo";
 
 export function loadContext(): ProjectContext {
   const filePath = path.join(process.cwd(), "CFORGE_DEV.md");
@@ -11,8 +12,11 @@ export function loadContext(): ProjectContext {
 
   const content = fs.readFileSync(filePath, "utf-8");
 
-  const repoOwner = extractField(content, "Repo") ?.split("/")[0] ?? "unknown";
-  const repoName = extractField(content, "Repo")?.split("/")[1] ?? "unknown";
+  const repoField = extractField(content, "Repo");
+  const fromGit = (!repoField || !repoField.includes("/")) ? resolveRepoFromGit() : undefined;
+
+  const repoOwner = repoField?.split("/")[0] ?? fromGit?.owner ?? "unknown";
+  const repoName = repoField?.split("/")[1] ?? fromGit?.repo ?? "unknown";
   const stack = extractField(content, "Stack") ?? "TypeScript";
   const architecture = extractLine(content, "Architecture") ?? "Clean Architecture";
 

--- a/src/cli/utils/resolveRepo.ts
+++ b/src/cli/utils/resolveRepo.ts
@@ -1,0 +1,46 @@
+import { execSync } from "child_process";
+
+export interface RepoCoordinates {
+  owner: string;
+  repo: string;
+}
+
+/**
+ * Parses a git remote URL (SSH or HTTPS) and extracts owner and repo name.
+ *
+ * Handles:
+ *   https://github.com/owner/repo.git
+ *   https://github.com/owner/repo
+ *   git@github.com:owner/repo.git
+ *   git@github.com:owner/repo
+ */
+export function parseGitRemoteUrl(url: string): RepoCoordinates | undefined {
+  const trimmed = url.trim();
+
+  // HTTPS: https://github.com/owner/repo[.git]
+  const httpsMatch = trimmed.match(/^https?:\/\/[^/]+\/([^/]+)\/([^/]+?)(?:\.git)?\s*$/);
+  if (httpsMatch) {
+    return { owner: httpsMatch[1], repo: httpsMatch[2] };
+  }
+
+  // SSH: git@github.com:owner/repo[.git]
+  const sshMatch = trimmed.match(/^git@[^:]+:([^/]+)\/([^/]+?)(?:\.git)?\s*$/);
+  if (sshMatch) {
+    return { owner: sshMatch[1], repo: sshMatch[2] };
+  }
+
+  return undefined;
+}
+
+/**
+ * Resolves repo owner and name from `git remote get-url origin`.
+ * Returns undefined if git is unavailable or the URL cannot be parsed.
+ */
+export function resolveRepoFromGit(): RepoCoordinates | undefined {
+  try {
+    const url = execSync("git remote get-url origin", { encoding: "utf-8" });
+    return parseGitRemoteUrl(url);
+  } catch {
+    return undefined;
+  }
+}

--- a/tests/cli/resolveRepo.test.ts
+++ b/tests/cli/resolveRepo.test.ts
@@ -1,0 +1,129 @@
+import { parseGitRemoteUrl, resolveRepoFromGit } from "../../src/cli/utils/resolveRepo";
+
+jest.mock("child_process");
+import { execSync } from "child_process";
+const mockExecSync = execSync as jest.MockedFunction<typeof execSync>;
+
+describe("parseGitRemoteUrl", () => {
+  describe("HTTPS URLs", () => {
+    it("parses standard HTTPS URL with .git suffix", () => {
+      expect(parseGitRemoteUrl("https://github.com/owner/repo.git")).toEqual({
+        owner: "owner",
+        repo: "repo",
+      });
+    });
+
+    it("parses HTTPS URL without .git suffix", () => {
+      expect(parseGitRemoteUrl("https://github.com/owner/repo")).toEqual({
+        owner: "owner",
+        repo: "repo",
+      });
+    });
+
+    it("parses HTTPS URL with trailing whitespace/newline", () => {
+      expect(parseGitRemoteUrl("https://github.com/myorg/my-repo.git\n")).toEqual({
+        owner: "myorg",
+        repo: "my-repo",
+      });
+    });
+
+    it("parses HTTPS URL with hyphenated org and repo names", () => {
+      expect(parseGitRemoteUrl("https://github.com/cognitive-forge/cforge-dev.git")).toEqual({
+        owner: "cognitive-forge",
+        repo: "cforge-dev",
+      });
+    });
+
+    it("parses HTTP (non-TLS) URL", () => {
+      expect(parseGitRemoteUrl("http://github.com/owner/repo.git")).toEqual({
+        owner: "owner",
+        repo: "repo",
+      });
+    });
+  });
+
+  describe("SSH URLs", () => {
+    it("parses standard SSH URL with .git suffix", () => {
+      expect(parseGitRemoteUrl("git@github.com:owner/repo.git")).toEqual({
+        owner: "owner",
+        repo: "repo",
+      });
+    });
+
+    it("parses SSH URL without .git suffix", () => {
+      expect(parseGitRemoteUrl("git@github.com:owner/repo")).toEqual({
+        owner: "owner",
+        repo: "repo",
+      });
+    });
+
+    it("parses SSH URL with trailing whitespace/newline", () => {
+      expect(parseGitRemoteUrl("git@github.com:myorg/my-repo.git\n")).toEqual({
+        owner: "myorg",
+        repo: "my-repo",
+      });
+    });
+
+    it("parses SSH URL for GitLab host", () => {
+      expect(parseGitRemoteUrl("git@gitlab.com:owner/repo.git")).toEqual({
+        owner: "owner",
+        repo: "repo",
+      });
+    });
+  });
+
+  describe("invalid URLs", () => {
+    it("returns undefined for empty string", () => {
+      expect(parseGitRemoteUrl("")).toBeUndefined();
+    });
+
+    it("returns undefined for a plain string", () => {
+      expect(parseGitRemoteUrl("not-a-url")).toBeUndefined();
+    });
+
+    it("returns undefined for HTTPS URL missing repo segment", () => {
+      expect(parseGitRemoteUrl("https://github.com/owner")).toBeUndefined();
+    });
+
+    it("returns undefined for SSH URL without slash in path", () => {
+      expect(parseGitRemoteUrl("git@github.com:no-slash")).toBeUndefined();
+    });
+  });
+});
+
+describe("resolveRepoFromGit", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns parsed owner and repo from HTTPS remote URL", () => {
+    mockExecSync.mockReturnValueOnce("https://github.com/Cognitive-Forge-Systems/cforge-dev.git\n");
+
+    expect(resolveRepoFromGit()).toEqual({
+      owner: "Cognitive-Forge-Systems",
+      repo: "cforge-dev",
+    });
+    expect(mockExecSync).toHaveBeenCalledWith("git remote get-url origin", { encoding: "utf-8" });
+  });
+
+  it("returns parsed owner and repo from SSH remote URL", () => {
+    mockExecSync.mockReturnValueOnce("git@github.com:Cognitive-Forge-Systems/cforge-dev.git\n");
+
+    expect(resolveRepoFromGit()).toEqual({
+      owner: "Cognitive-Forge-Systems",
+      repo: "cforge-dev",
+    });
+  });
+
+  it("returns undefined when git command fails", () => {
+    mockExecSync.mockImplementationOnce(() => { throw new Error("not a git repo"); });
+
+    expect(resolveRepoFromGit()).toBeUndefined();
+  });
+
+  it("returns undefined when remote URL cannot be parsed", () => {
+    mockExecSync.mockReturnValueOnce("not-a-valid-url");
+
+    expect(resolveRepoFromGit()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
Automated implementation via cforge-dev --auto

Fix: repo detection from git remote URL

## Issue
Closes #24

## Implementation
Done. Here's a summary of what was implemented:

**Files changed:**
- `src/cli/utils/resolveRepo.ts` — new file with:
  - `parseGitRemoteUrl(url)` — pure function handling both SSH (`git@github.com:owner/repo.git`) and HTTPS (`https://github.com/owner/repo.git`) URLs
  - `resolveRepoFromGit()` — runs `git remote get-url origin` and delegates to the parser
- `src/cli/utils/loadContext.ts` — updated to call `resolveRepoFromGit()` as fallback when the `Repo` field in `CFORGE_DEV.md` is missing or m

## Cost
Claude session cost: $0.4661 (18 turns)