### PR TITLE
fix: ClaudeCodeRunner compat with Claude Code CLI v2.1.92

### DIFF
--- a/src/infrastructure/claude/ClaudeCodeRunner.ts
+++ b/src/infrastructure/claude/ClaudeCodeRunner.ts
@@ -1,7 +1,4 @@
-import * as fs from "fs";
-import * as path from "path";
-import * as os from "os";
-import { execSync } from "child_process";
+import { execSync, spawn } from "child_process";
 import { CodeRunner, RunOptions, RunResult } from "../../domain/interfaces/CodeRunner";
 
 const DEFAULT_MODEL = "claude-sonnet-4-6";
@@ -31,52 +28,61 @@ export class ClaudeCodeRunner implements CodeRunner {
       throw new Error("claude CLI not found — install Claude Code first");
     }
 
-    // Write prompt to temp file
-    const tmpFile = path.join(os.tmpdir(), `prompt-${Date.now()}.txt`);
-    fs.writeFileSync(tmpFile, prompt);
+    const args = [
+      "--print",
+      "--model", model,
+      "--dangerously-skip-permissions",
+      "--allowed-tools", tools.join(","),
+      "--max-budget-usd", String(budget),
+      "--output-format", "json",
+    ];
 
-    try {
-      const toolsArg = tools.map((t) => `"${t}"`).join(",");
-      const cmd = [
-        "CLAUDECODE=",
-        "claude",
-        "--print",
-        `--model ${model}`,
-        "--dangerously-skip-permissions",
-        `--allowedTools ${toolsArg}`,
-        `--max-budget-usd ${budget}`,
-        "--output-format json",
-        `< "${tmpFile}"`,
-      ].join(" ");
-
-      const output = execSync(cmd, {
+    const output = await new Promise<string>((resolve, reject) => {
+      const child = spawn("claude", args, {
         cwd: workingDir,
-        encoding: "utf-8",
-        maxBuffer: 10 * 1024 * 1024,
-        timeout: 600000, // 10 minutes
-        env: { ...process.env, CLAUDECODE: "" },
+        stdio: ["pipe", "pipe", "pipe"],
       });
 
-      let parsed: ClaudeJsonResponse;
-      try {
-        parsed = JSON.parse(output.trim());
-      } catch {
-        throw new Error(`Failed to parse claude output: ${output.slice(0, 200)}`);
-      }
+      let stdout = "";
+      let stderr = "";
 
-      return {
-        success: !parsed.is_error && parsed.subtype === "success",
-        output: parsed.result ?? "",
-        cost: parsed.total_cost_usd ?? 0,
-        turns: parsed.num_turns ?? 0,
-        stopReason: parsed.stop_reason ?? "unknown",
-      };
-    } finally {
-      try {
-        fs.unlinkSync(tmpFile);
-      } catch {
-        // Ignore cleanup errors
-      }
+      child.stdout.on("data", (data: Buffer) => {
+        stdout += data.toString();
+      });
+
+      child.stderr.on("data", (data: Buffer) => {
+        stderr += data.toString();
+      });
+
+      child.stdin.write(prompt);
+      child.stdin.end();
+
+      child.on("close", (code: number | null) => {
+        if (code !== 0) {
+          reject(new Error(`claude exited with code ${code}: ${stderr}`));
+        } else {
+          resolve(stdout);
+        }
+      });
+
+      child.on("error", (err: Error) => {
+        reject(err);
+      });
+    });
+
+    let parsed: ClaudeJsonResponse;
+    try {
+      parsed = JSON.parse(output.trim());
+    } catch {
+      throw new Error(`Failed to parse claude output: ${output.slice(0, 200)}`);
     }
+
+    return {
+      success: !parsed.is_error && parsed.subtype === "success",
+      output: parsed.result ?? "",
+      cost: parsed.total_cost_usd ?? 0,
+      turns: parsed.num_turns ?? 0,
+      stopReason: parsed.stop_reason ?? "unknown",
+    };
   }
 }

--- a/tests/infrastructure/ClaudeCodeRunner.test.ts
+++ b/tests/infrastructure/ClaudeCodeRunner.test.ts
@@ -1,7 +1,10 @@
 import { ClaudeCodeRunner } from "../../src/infrastructure/claude/ClaudeCodeRunner";
+import { EventEmitter } from "events";
+import { PassThrough } from "stream";
 
 jest.mock("child_process", () => ({
   execSync: jest.fn(),
+  spawn: jest.fn(),
 }));
 
 jest.mock("fs", () => {
@@ -14,27 +17,121 @@ jest.mock("fs", () => {
   };
 });
 
-const { execSync } = require("child_process");
-const fs = require("fs");
+const { execSync, spawn } = require("child_process");
+
+function mockSpawnSuccess(jsonResponse: string) {
+  (spawn as jest.Mock).mockImplementation(() => {
+    const child = Object.assign(new EventEmitter(), {
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      stdin: new PassThrough(),
+    });
+    process.nextTick(() => {
+      child.stdout.push(jsonResponse);
+      child.stdout.push(null);
+      child.emit("close", 0);
+    });
+    return child;
+  });
+  // `which claude` check
+  (execSync as jest.Mock).mockReturnValue("/usr/bin/claude");
+}
+
+function mockSpawnFailure(code: number, stderr: string) {
+  (spawn as jest.Mock).mockImplementation(() => {
+    const child = Object.assign(new EventEmitter(), {
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      stdin: new PassThrough(),
+    });
+    process.nextTick(() => {
+      child.stderr.push(stderr);
+      child.stderr.push(null);
+      child.stdout.push(null);
+      child.emit("close", code);
+    });
+    return child;
+  });
+  (execSync as jest.Mock).mockReturnValue("/usr/bin/claude");
+}
+
+const successJson = JSON.stringify({
+  type: "result",
+  subtype: "success",
+  is_error: false,
+  result: "Implementation complete",
+  total_cost_usd: 0.05,
+  num_turns: 3,
+  stop_reason: "end_turn",
+});
 
 describe("ClaudeCodeRunner", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (fs.existsSync as jest.Mock).mockReturnValue(true);
   });
 
-  it("should return RunResult with cost and turns on successful run", async () => {
-    const jsonResponse = JSON.stringify({
-      type: "result",
-      subtype: "success",
-      is_error: false,
-      result: "Implementation complete",
-      total_cost_usd: 0.05,
-      num_turns: 3,
-      stop_reason: "end_turn",
-    });
-    (execSync as jest.Mock).mockReturnValue(jsonResponse);
+  // ── Bug-proving tests (TDD red phase) ────────────────────────────
 
+  it("should NOT override env (no CLAUDECODE= prefix)", async () => {
+    mockSpawnSuccess(successJson);
+    const runner = new ClaudeCodeRunner();
+    await runner.run("prompt", "/tmp/test", {});
+
+    const spawnCall = (spawn as jest.Mock).mock.calls[0];
+    const spawnOpts = spawnCall[2];
+    // env must not be explicitly set — child inherits parent env naturally
+    expect(spawnOpts.env).toBeUndefined();
+  });
+
+  it("should use async spawn instead of execSync for claude invocation", async () => {
+    mockSpawnSuccess(successJson);
+    const runner = new ClaudeCodeRunner();
+    await runner.run("prompt", "/tmp/test", {});
+
+    // spawn must be called for the claude command
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn).toHaveBeenCalledWith(
+      "claude",
+      expect.any(Array),
+      expect.any(Object)
+    );
+
+    // execSync should only be called once (for `which claude`)
+    expect(execSync).toHaveBeenCalledTimes(1);
+    expect(execSync).toHaveBeenCalledWith(
+      "which claude",
+      expect.objectContaining({ encoding: "utf-8" })
+    );
+  });
+
+  it("should pass --allowed-tools as a single comma-separated value without quotes", async () => {
+    mockSpawnSuccess(successJson);
+    const runner = new ClaudeCodeRunner();
+    await runner.run("prompt", "/tmp/test", {
+      allowedTools: ["Bash", "Edit", "Read"],
+    });
+
+    const args: string[] = (spawn as jest.Mock).mock.calls[0][1];
+    const toolsIdx = args.indexOf("--allowed-tools");
+    expect(toolsIdx).toBeGreaterThan(-1);
+    const toolsValue = args[toolsIdx + 1];
+    // Must be plain comma-separated, no shell quotes
+    expect(toolsValue).toBe("Bash,Edit,Read");
+  });
+
+  it("should not have a hardcoded timeout", async () => {
+    mockSpawnSuccess(successJson);
+    const runner = new ClaudeCodeRunner();
+    await runner.run("prompt", "/tmp/test", {});
+
+    const spawnOpts = (spawn as jest.Mock).mock.calls[0][2];
+    expect(spawnOpts.timeout).toBeUndefined();
+  });
+
+  // ── Existing behaviour (green phase) ─────────────────────────────
+
+  it("should return RunResult with cost and turns on successful run", async () => {
+    mockSpawnSuccess(successJson);
     const runner = new ClaudeCodeRunner();
     const result = await runner.run("implement this", "/tmp/test", {});
 
@@ -44,72 +141,122 @@ describe("ClaudeCodeRunner", () => {
     expect(result.output).toBe("Implementation complete");
   });
 
-  it("should write prompt to temp file before running", async () => {
-    const jsonResponse = JSON.stringify({
-      type: "result",
-      subtype: "success",
-      is_error: false,
-      result: "done",
-      total_cost_usd: 0.01,
-      num_turns: 1,
-      stop_reason: "end_turn",
+  it("should send prompt via stdin", async () => {
+    let capturedStdin = "";
+    (spawn as jest.Mock).mockImplementation(() => {
+      const child = Object.assign(new EventEmitter(), {
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+        stdin: new PassThrough(),
+      });
+      child.stdin.on("data", (chunk: Buffer) => {
+        capturedStdin += chunk.toString();
+      });
+      process.nextTick(() => {
+        child.stdout.push(successJson);
+        child.stdout.push(null);
+        child.emit("close", 0);
+      });
+      return child;
     });
-    (execSync as jest.Mock).mockReturnValue(jsonResponse);
+    (execSync as jest.Mock).mockReturnValue("/usr/bin/claude");
 
     const runner = new ClaudeCodeRunner();
     await runner.run("test prompt content", "/tmp/test", {});
 
-    expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
-    const [writtenPath, writtenContent] = (fs.writeFileSync as jest.Mock).mock.calls[0];
-    expect(writtenPath).toContain("prompt-");
-    expect(writtenContent).toBe("test prompt content");
-  });
-
-  it("should clean up temp file after run", async () => {
-    const jsonResponse = JSON.stringify({
-      type: "result",
-      subtype: "success",
-      is_error: false,
-      result: "done",
-      total_cost_usd: 0.01,
-      num_turns: 1,
-      stop_reason: "end_turn",
-    });
-    (execSync as jest.Mock).mockReturnValue(jsonResponse);
-
-    const runner = new ClaudeCodeRunner();
-    await runner.run("prompt", "/tmp/test", {});
-
-    expect(fs.unlinkSync).toHaveBeenCalledTimes(1);
-    const [deletedPath] = (fs.unlinkSync as jest.Mock).mock.calls[0];
-    expect(deletedPath).toContain("prompt-");
+    expect(capturedStdin).toBe("test prompt content");
   });
 
   it("should throw descriptive error when claude CLI not found", async () => {
-    (execSync as jest.Mock).mockImplementation((cmd: string) => {
-      if (cmd === "which claude") {
-        throw new Error("command not found");
-      }
-      return "";
+    (execSync as jest.Mock).mockImplementation(() => {
+      throw new Error("command not found");
     });
 
     const runner = new ClaudeCodeRunner();
-
     await expect(runner.run("prompt", "/tmp/test", {})).rejects.toThrow(
       "claude CLI not found — install Claude Code first"
     );
   });
 
   it("should throw descriptive error on JSON parse failure", async () => {
-    (execSync as jest.Mock).mockImplementation((cmd: string) => {
-      if (cmd === "which claude") return "/usr/bin/claude";
-      return "not valid json at all";
+    (spawn as jest.Mock).mockImplementation(() => {
+      const child = Object.assign(new EventEmitter(), {
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+        stdin: new PassThrough(),
+      });
+      process.nextTick(() => {
+        child.stdout.push("not valid json at all");
+        child.stdout.push(null);
+        child.emit("close", 0);
+      });
+      return child;
     });
+    (execSync as jest.Mock).mockReturnValue("/usr/bin/claude");
 
     const runner = new ClaudeCodeRunner();
-
     await expect(runner.run("prompt", "/tmp/test", {})).rejects.toThrow(
       "Failed to parse claude output"
     );
+  });
+
+  it("should throw on non-zero exit code", async () => {
+    mockSpawnFailure(1, "something went wrong");
+    const runner = new ClaudeCodeRunner();
+
+    await expect(runner.run("prompt", "/tmp/test", {})).rejects.toThrow(
+      "claude exited with code 1"
+    );
+  });
+
+  it("should throw on spawn error", async () => {
+    (spawn as jest.Mock).mockImplementation(() => {
+      const child = Object.assign(new EventEmitter(), {
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+        stdin: new PassThrough(),
+      });
+      process.nextTick(() => {
+        child.emit("error", new Error("spawn ENOENT"));
+      });
+      return child;
+    });
+    (execSync as jest.Mock).mockReturnValue("/usr/bin/claude");
+
+    const runner = new ClaudeCodeRunner();
+    await expect(runner.run("prompt", "/tmp/test", {})).rejects.toThrow(
+      "spawn ENOENT"
+    );
+  });
+
+  it("should pass correct default flags", async () => {
+    mockSpawnSuccess(successJson);
+    const runner = new ClaudeCodeRunner();
+    await runner.run("prompt", "/tmp/work", {});
+
+    const [bin, args, opts] = (spawn as jest.Mock).mock.calls[0];
+    expect(bin).toBe("claude");
+    expect(args).toEqual([
+      "--print",
+      "--model", "claude-sonnet-4-6",
+      "--dangerously-skip-permissions",
+      "--allowed-tools", "Bash,Edit,Read,Write,Glob,Grep",
+      "--max-budget-usd", "1",
+      "--output-format", "json",
+    ]);
+    expect(opts.cwd).toBe("/tmp/work");
+  });
+
+  it("should respect custom model and budget options", async () => {
+    mockSpawnSuccess(successJson);
+    const runner = new ClaudeCodeRunner();
+    await runner.run("prompt", "/tmp/test", {
+      model: "claude-opus-4-6",
+      maxBudgetUsd: 5.0,
+    });
+
+    const args: string[] = (spawn as jest.Mock).mock.calls[0][1];
+    expect(args).toContain("claude-opus-4-6");
+    expect(args).toContain("5");
   });
 });


### PR DESCRIPTION
## Summary
Closes #27

- **Remove `CLAUDECODE=` env var prefix** — caused `Command failed: CLAUDECODE= claude ...` errors (donna-ai repro)
- **Switch from `execSync` to async `spawn`** — eliminates `spawnSync /bin/sh ETIMEDOUT` on complex issues (cforge-dev repro); no hardcoded timeout
- **Fix `--allowed-tools` format** — plain comma-separated values without shell quotes, matching CLI v2.1.92 spec
- **Send prompt via stdin** — replaces temp file + shell redirection with direct `child.stdin.write()`

All flags verified against `claude --help` (v2.1.92). Output is still parseable JSON (`--output-format json --print`).

## Test plan
- [x] TDD: wrote 7 new failing tests that prove both bugs, then fixed
- [x] All 12 ClaudeCodeRunner tests pass
- [x] Full suite: 157/157 tests pass across 15 suites
- [x] Verified flag names match `claude --help` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)