### PR TITLE
feat: Improve CLI visual design to match Claude Code terminal aesthetic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,10 @@
       "license": "GPL-3.0-only",
       "dependencies": {
         "@octokit/rest": "^21.1.1",
-        "dotenv": "^17.3.1"
+        "boxen": "^5.1.2",
+        "chalk": "^4.1.2",
+        "dotenv": "^17.3.1",
+        "ora": "^5.4.1"
       },
       "bin": {
         "cforge-dev": "dist/cli/index.js"
@@ -1305,6 +1308,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -1325,7 +1337,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1335,7 +1346,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1501,6 +1511,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -1519,6 +1549,63 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
       "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
       "license": "Apache-2.0"
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/boxen": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
@@ -1601,6 +1688,30 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -1653,7 +1764,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -1699,6 +1809,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -1712,6 +1858,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/co": {
@@ -1736,7 +1891,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1749,7 +1903,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -1853,6 +2006,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -1919,7 +2084,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/error-ex": {
@@ -2206,7 +2370,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2241,6 +2404,26 @@
       "engines": {
         "node": ">=10.17.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/import-local": {
       "version": "3.2.0",
@@ -2288,7 +2471,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/is-arrayish": {
@@ -2318,7 +2500,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2332,6 +2513,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-number": {
@@ -2352,6 +2542,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3145,6 +3347,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3226,7 +3444,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3327,13 +3544,35 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3559,6 +3798,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3623,6 +3876,39 @@
         "node": ">=10"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -3660,7 +3946,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/sisteransi": {
@@ -3721,6 +4006,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -3739,7 +4033,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -3754,7 +4047,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -3800,7 +4092,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -4075,6 +4366,12 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -4107,6 +4404,15 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4123,6 +4429,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -4134,7 +4452,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
   },
   "dependencies": {
     "@octokit/rest": "^21.1.1",
-    "dotenv": "^17.3.1"
+    "boxen": "^5.1.2",
+    "chalk": "^4.1.2",
+    "dotenv": "^17.3.1",
+    "ora": "^5.4.1"
   }
 }

--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -3,6 +3,7 @@ import { ContractLoader } from "../../infrastructure/filesystem/ContractLoader";
 import { CForgePromptGenerator } from "../../infrastructure/cforge/CForgePromptGenerator";
 import { GovernanceAuditor } from "../../application/use-cases/GovernanceAuditor";
 import { USAGE_AUDIT } from "../validation";
+import { c } from "../utils/ui";
 
 export async function auditCommand(flags: string[] = []): Promise<void> {
   if (flags.includes("--help")) {
@@ -17,7 +18,7 @@ export async function auditCommand(flags: string[] = []): Promise<void> {
   const contracts = loader.loadAll();
 
   if (contracts.length === 0) {
-    console.error("No governance contracts found in contracts/ directory.");
+    console.error(c.error("No governance contracts found in contracts/ directory."));
     process.exit(1);
   }
 
@@ -36,9 +37,9 @@ export async function auditCommand(flags: string[] = []): Promise<void> {
   const result = await auditor.execute({ workingDir, contracts });
 
   console.log("");
-  console.log("══════════════════════════════════════");
-  console.log("GOVERNANCE AUDIT — cforge-dev");
-  console.log("══════════════════════════════════════");
+  console.log(c.bold("══════════════════════════════════════"));
+  console.log(c.bold("GOVERNANCE AUDIT — cforge-dev"));
+  console.log(c.bold("══════════════════════════════════════"));
 
   // Group results by contract
   const byContract = new Map<string, typeof result.results>();
@@ -50,23 +51,32 @@ export async function auditCommand(flags: string[] = []): Promise<void> {
 
   for (const contract of contracts) {
     const results = byContract.get(contract.id) ?? [];
-    console.log(`\n  CONTRACT: ${contract.title}`);
-    console.log("  ──────────────────────────────");
+    console.log(`\n  ${c.info("CONTRACT:")} ${contract.title}`);
+    console.log(c.dim("  ──────────────────────────────"));
     for (const r of results) {
-      const icon = r.passed ? "\u2705" : r.rule.severity === "error" ? "\u274C" : "\u26A0\uFE0F ";
+      const icon = r.passed
+        ? c.success("\u2705")
+        : r.rule.severity === "error"
+          ? c.error("\u274C")
+          : c.warning("\u26A0\uFE0F ");
       const pad = r.rule.id.padEnd(24);
-      console.log(`  ${icon} ${pad} ${r.message}`);
+      const message = r.passed ? r.message : r.rule.severity === "error" ? c.error(r.message) : c.warning(r.message);
+      console.log(`  ${icon} ${pad} ${message}`);
     }
   }
 
+  const passedStr  = c.success(`${result.passed} passed`);
+  const warningStr = result.warnings > 0 ? c.warning(`${result.warnings} warning(s)`) : `${result.warnings} warning(s)`;
+  const errorStr   = result.errors > 0   ? c.error(`${result.errors} error(s)`)       : `${result.errors} error(s)`;
+
   console.log("");
-  console.log("══════════════════════════════════════");
-  console.log(`  RESULT: ${result.passed} passed  ${result.warnings} warning(s)  ${result.errors} error(s)`);
-  console.log("══════════════════════════════════════");
+  console.log(c.bold("══════════════════════════════════════"));
+  console.log(`  RESULT: ${passedStr}  ${warningStr}  ${errorStr}`);
+  console.log(c.bold("══════════════════════════════════════"));
 
   if (result.fixPlan) {
-    console.log("\n  FIX PLAN");
-    console.log("  ─────────");
+    console.log(`\n  ${c.warning("FIX PLAN")}`);
+    console.log(c.dim("  ─────────"));
     console.log(`  ${result.fixPlan.split("\n").join("\n  ")}`);
   }
 

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -5,6 +5,7 @@ import { ChatSession } from "../../application/use-cases/ChatSession";
 import { RepoStateLoader } from "../../application/use-cases/RepoStateLoader";
 import { ImplementIssue } from "../../application/use-cases/ImplementIssue";
 import { loadContext } from "../utils/loadContext";
+import { c, createSpinner } from "../utils/ui";
 
 const HELP = `
 Commands:
@@ -24,21 +25,23 @@ export async function chatCommand(): Promise<void> {
   const promptGen = new CForgePromptGenerator();
   const loader = new RepoStateLoader(gh);
 
-  console.log("Loading repo state...");
+  const spinner = createSpinner("Loading repo state…");
   const repoState = await loader.execute();
+  spinner.stop();
+
   const session = new ChatSession(context, repoState);
 
   console.log("");
   console.log("╔════════════════════════════════════════╗");
-  console.log("║     cforge-dev — Planning Session      ║");
+  console.log(`║  ${c.bold("cforge-dev")} ${c.dim("— Planning Session")}      ║`);
   console.log("╚════════════════════════════════════════╝");
-  console.log(`  Repo:     ${context.repoOwner}/${context.repoName}`);
-  console.log(`  Model:    ${session.model}`);
+  console.log(`  ${c.dim("Repo:")}     ${context.repoOwner}/${context.repoName}`);
+  console.log(`  ${c.dim("Model:")}    ${session.model}`);
   console.log("");
   console.log(session.getRepoSummary());
   console.log("");
-  console.log("  Type /help for commands, /exit to quit.");
-  console.log("────────────────────────────────────────");
+  console.log(c.dim("  Type /help for commands, /exit to quit."));
+  console.log(c.dim("────────────────────────────────────────"));
 
   const isTTY = process.stdin.isTTY === true;
   let lineQueue: string[] | null = null;
@@ -64,14 +67,14 @@ export async function chatCommand(): Promise<void> {
     if (lineQueue) {
       const next = lineQueue.shift();
       if (next !== undefined) {
-        console.log(`\nyou → ${next}`);
+        console.log(`\n${c.dim("you →")} ${next}`);
         return Promise.resolve(next);
       }
       return Promise.resolve(null);
     }
     return new Promise((resolve) => {
       if (closed) { resolve(null); return; }
-      rl.question("\nyou → ", (answer) => resolve(answer.trim()));
+      rl.question(`\n${c.dim("you →")} `, (answer) => resolve(answer.trim()));
     });
   };
 
@@ -96,10 +99,10 @@ export async function chatCommand(): Promise<void> {
       session.updateRepoState(fresh);
       console.log("");
       if (fresh.openIssues.length === 0) {
-        console.log("  No open issues.");
+        console.log(c.dim("  No open issues."));
       } else {
         for (const issue of fresh.openIssues) {
-          console.log(`  #${issue.number}  [${issue.type}]  ${issue.title}`);
+          console.log(`  #${issue.number}  ${c.issueType(issue.type)}  ${issue.title}`);
         }
       }
       continue;
@@ -110,7 +113,7 @@ export async function chatCommand(): Promise<void> {
       session.updateRepoState(fresh);
       console.log("");
       if (fresh.openPullRequests.length === 0) {
-        console.log("  No open PRs.");
+        console.log(c.dim("  No open PRs."));
       } else {
         for (const pr of fresh.openPullRequests) {
           console.log(`  #${pr.number}  ${pr.title} (${pr.branch})`);
@@ -126,10 +129,11 @@ export async function chatCommand(): Promise<void> {
     }
 
     if (input === "/refresh") {
-      console.log("Refreshing repo state...");
+      const refreshSpinner = createSpinner("Refreshing repo state…");
       const fresh = await loader.execute();
       session.updateRepoState(fresh);
-      console.log("Done.\n");
+      refreshSpinner.stop();
+      console.log(c.success("Done.\n"));
       console.log(session.getRepoSummary());
       continue;
     }
@@ -138,7 +142,7 @@ export async function chatCommand(): Promise<void> {
       const newModel = input.slice(7).trim();
       if (newModel) {
         session.model = newModel;
-        console.log(`  Model switched to: ${newModel}`);
+        console.log(`  ${c.success("Model switched to:")} ${newModel}`);
       }
       continue;
     }
@@ -146,24 +150,26 @@ export async function chatCommand(): Promise<void> {
     if (input.startsWith("/implement ")) {
       const num = parseInt(input.slice(11).trim(), 10);
       if (isNaN(num)) {
-        console.log("  Usage: /implement <issue-number>");
+        console.log(c.warning("  Usage: /implement <issue-number>"));
         continue;
       }
       try {
         const impl = new ImplementIssue(gh, promptGen);
+        const implSpinner = createSpinner("Fetching issue…");
         const result = await impl.execute({ issueNumber: num, context });
-        console.log(`\n  Issue: #${result.issue.number} — ${result.issue.title}`);
-        console.log(`  Branch: ${result.branch}\n`);
-        console.log("══ CLAUDE CODE PROMPT ══");
+        implSpinner.stop();
+        console.log(`\n  ${c.bold("Issue:")} #${result.issue.number} — ${result.issue.title}`);
+        console.log(`  ${c.bold("Branch:")} ${result.branch}\n`);
+        console.log(c.info("══ CLAUDE CODE PROMPT ══"));
         console.log(result.prompt);
-        console.log("══ END PROMPT ══\n");
-        console.log("  Next steps:");
+        console.log(c.info("══ END PROMPT ══\n"));
+        console.log(`  ${c.bold("Next steps:")}`);
         result.nextSteps.forEach((step, i) => {
           console.log(`    ${i + 1}. ${step}`);
         });
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
-        console.log(`  Error: ${msg}`);
+        console.log(`  ${c.error("Error:")} ${msg}`);
       }
       continue;
     }
@@ -175,10 +181,10 @@ export async function chatCommand(): Promise<void> {
     try {
       const response = await callLLM(messages, session.model);
       session.addMessage("assistant", response);
-      console.log(`\ncforge-dev → ${response}`);
+      console.log(`\n${c.info("cforge-dev →")} ${response}`);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
-      console.log(`  Error: ${msg}`);
+      console.log(`  ${c.error("Error:")} ${msg}`);
       // Remove the user message if LLM call failed
       session.history.pop();
     }

--- a/src/cli/commands/implement.ts
+++ b/src/cli/commands/implement.ts
@@ -6,6 +6,7 @@ import { ImplementIssue } from "../../application/use-cases/ImplementIssue";
 import { AutoImplement } from "../../application/use-cases/AutoImplement";
 import { loadContext } from "../utils/loadContext";
 import { validatePresence, validateNumericIssueNumber, USAGE_IMPLEMENT } from "../validation";
+import { c, createSpinner } from "../utils/ui";
 
 export async function implementCommand(issueNumberStr: string, flags: string[] = []): Promise<void> {
   if (issueNumberStr === "--help" || flags.includes("--help")) {
@@ -43,16 +44,18 @@ async function runManualImplement(issueNumber: number): Promise<void> {
   const promptGen = new CForgePromptGenerator();
   const impl = new ImplementIssue(gh, promptGen);
 
+  const spinner = createSpinner("Fetching issue…");
   const result = await impl.execute({ issueNumber, context });
+  spinner.stop();
 
-  console.log(`\nIssue: #${result.issue.number} — ${result.issue.title}`);
-  console.log(`Branch: ${result.branch}\n`);
+  console.log(`\n${c.bold("Issue:")} #${result.issue.number} — ${result.issue.title}`);
+  console.log(`${c.bold("Branch:")} ${result.branch}\n`);
 
-  console.log("══ CLAUDE CODE PROMPT ══");
+  console.log(c.info("══ CLAUDE CODE PROMPT ══"));
   console.log(result.prompt);
-  console.log("══ END PROMPT ══\n");
+  console.log(c.info("══ END PROMPT ══\n"));
 
-  console.log("Next steps:");
+  console.log(c.bold("Next steps:"));
   result.nextSteps.forEach((step, i) => {
     console.log(`  ${i + 1}. ${step}`);
   });
@@ -88,9 +91,11 @@ async function runAutoImplement(issueNumber: number, maxBudgetUsd?: number): Pro
   const auto = new AutoImplement(gh, promptGen, codeRunner, testRunner);
 
   console.log("");
-  console.log("══════════════════════════════════════");
-  console.log(`AUTO-IMPLEMENT — Issue #${issueNumber}`);
-  console.log("══════════════════════════════════════");
+  console.log(c.bold("══════════════════════════════════════"));
+  console.log(c.bold(`AUTO-IMPLEMENT — Issue #${issueNumber}`));
+  console.log(c.bold("══════════════════════════════════════"));
+
+  const spinner = createSpinner("Running Claude Code…");
 
   const result = await auto.execute({
     issueNumber,
@@ -98,27 +103,30 @@ async function runAutoImplement(issueNumber: number, maxBudgetUsd?: number): Pro
     maxBudgetUsd,
   });
 
+  spinner.stop();
+
   if (result.success) {
-    console.log(`  \u2713 Claude session complete ($${result.cost.toFixed(4)}, ${result.turns} turns)`);
-    console.log(`  \u2713 Tests passed`);
+    const metrics = c.metric(`$${result.cost.toFixed(4)}, ${result.turns} turns`);
+    console.log(`  ${c.success("\u2713")} Claude session complete (${metrics})`);
+    console.log(`  ${c.success("\u2713")} Tests passed`);
     if (result.prUrl) {
-      console.log(`  \u2713 PR opened: ${result.prUrl}`);
+      console.log(`  ${c.success("\u2713")} PR opened: ${result.prUrl}`);
     }
     if (result.retried) {
-      console.log("  (retry was needed)");
+      console.log(c.dim("  (retry was needed)"));
     }
     console.log("");
-    console.log("══════════════════════════════════════");
-    console.log("DONE — Review PR and merge when ready");
-    console.log(`cforge-dev verify ${issueNumber}`);
-    console.log("══════════════════════════════════════");
+    console.log(c.bold("══════════════════════════════════════"));
+    console.log(c.success("DONE — Review PR and merge when ready"));
+    console.log(c.dim(`cforge-dev verify ${issueNumber}`));
+    console.log(c.bold("══════════════════════════════════════"));
   } else {
-    console.log(`  \u2717 ${result.error}`);
+    console.log(`  ${c.error("\u2717")} ${result.error}`);
     if (result.retried) {
-      console.log("  \u2717 Tests failed after retry");
+      console.log(`  ${c.error("\u2717")} Tests failed after retry`);
     }
     if (result.manualStepsRequired.length > 0) {
-      console.log("\n  Manual steps required:");
+      console.log(`\n  ${c.warning("Manual steps required:")}`);
       result.manualStepsRequired.forEach((step, i) => {
         console.log(`    ${i + 1}. ${step}`);
       });

--- a/src/cli/commands/plan.ts
+++ b/src/cli/commands/plan.ts
@@ -5,6 +5,7 @@ import { CForgePromptGenerator } from "../../infrastructure/cforge/CForgePromptG
 import { PlanSprint } from "../../application/use-cases/PlanSprint";
 import { loadContext } from "../utils/loadContext";
 import { validatePresence, USAGE_PLAN } from "../validation";
+import { c, createSpinner } from "../utils/ui";
 
 function prompt(question: string): Promise<string> {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
@@ -29,7 +30,7 @@ export async function planCommand(prdFile: string): Promise<void> {
   }
 
   if (!fs.existsSync(prdFile)) {
-    console.error(`File not found: ${prdFile}`);
+    console.error(c.error(`File not found: ${prdFile}`));
     process.exit(1);
   }
 
@@ -43,7 +44,7 @@ export async function planCommand(prdFile: string): Promise<void> {
   const promptGen = new CForgePromptGenerator();
   const planner = new PlanSprint(gh, promptGen, context);
 
-  console.log("\nPlanning sprint...\n");
+  const spinner = createSpinner("Planning sprint…");
 
   const sprint = await planner.execute({
     prdContent,
@@ -51,9 +52,11 @@ export async function planCommand(prdFile: string): Promise<void> {
     milestoneDescription,
   });
 
-  console.log(`Milestone: ${sprint.milestone.title} (id: ${sprint.milestone.id})`);
-  console.log(`\nCreated ${sprint.issues.length} issues:\n`);
+  spinner.stop();
+
+  console.log(`\n${c.success("\u2713")} ${c.bold("Milestone:")} ${sprint.milestone.title} ${c.dim(`(id: ${sprint.milestone.id})`)}`);
+  console.log(`\n${c.bold(`Created ${sprint.issues.length} issues:`)}\n`);
   for (const issue of sprint.issues) {
-    console.log(`  #${issue.number} [${issue.type}] ${issue.title}`);
+    console.log(`  #${issue.number} ${c.issueType(issue.type)} ${issue.title}`);
   }
 }

--- a/src/cli/commands/release.ts
+++ b/src/cli/commands/release.ts
@@ -2,6 +2,7 @@ import { OctokitGitHubClient } from "../../infrastructure/github/OctokitGitHubCl
 import { CreateRelease } from "../../application/use-cases/CreateRelease";
 import { loadContext } from "../utils/loadContext";
 import { validatePresence, USAGE_RELEASE } from "../validation";
+import { c, createSpinner } from "../utils/ui";
 
 export async function releaseCommand(milestoneIdStr: string, version: string): Promise<void> {
   if (milestoneIdStr === "--help" || version === "--help") {
@@ -17,7 +18,7 @@ export async function releaseCommand(milestoneIdStr: string, version: string): P
 
   const milestoneId = parseInt(milestoneIdStr, 10);
   if (isNaN(milestoneId)) {
-    console.error("Milestone ID must be a valid integer");
+    console.error(c.error("Milestone ID must be a valid integer"));
     process.exit(1);
   }
 
@@ -25,14 +26,16 @@ export async function releaseCommand(milestoneIdStr: string, version: string): P
   const gh = new OctokitGitHubClient(context.repoOwner, context.repoName);
   const release = new CreateRelease(gh);
 
+  const spinner = createSpinner("Creating release…");
   const result = await release.execute({ milestoneId, version, context });
+  spinner.stop();
 
-  console.log(`\nRelease: ${result.tag}`);
-  console.log(`Version: ${result.version}`);
-  console.log(`Released at: ${result.releasedAt.toISOString()}\n`);
+  console.log(`\n${c.success("\u2713")} ${c.bold("Release:")} ${result.tag}`);
+  console.log(`${c.bold("Version:")} ${result.version}`);
+  console.log(`${c.bold("Released at:")} ${c.dim(result.releasedAt.toISOString())}\n`);
 
-  console.log("Changelog:");
+  console.log(c.bold("Changelog:"));
   console.log(result.changelog);
 
-  console.log(`\nhttps://github.com/${context.repoOwner}/${context.repoName}/releases/tag/${result.tag}`);
+  console.log(`\n${c.info(`https://github.com/${context.repoOwner}/${context.repoName}/releases/tag/${result.tag}`)}`);
 }

--- a/src/cli/commands/verify.ts
+++ b/src/cli/commands/verify.ts
@@ -3,6 +3,7 @@ import { CForgePromptGenerator } from "../../infrastructure/cforge/CForgePromptG
 import { VerifyIssue } from "../../application/use-cases/VerifyIssue";
 import { loadContext } from "../utils/loadContext";
 import { validatePresence, validateNumericIssueNumber, USAGE_VERIFY } from "../validation";
+import { c, createSpinner } from "../utils/ui";
 
 export async function verifyCommand(issueNumberStr: string): Promise<void> {
   if (issueNumberStr === "--help") {
@@ -29,26 +30,30 @@ export async function verifyCommand(issueNumberStr: string): Promise<void> {
   const promptGen = new CForgePromptGenerator();
   const verifier = new VerifyIssue(gh, promptGen);
 
+  const spinner = createSpinner("Verifying issue…");
   const result = await verifier.execute({ issueNumber, context });
+  spinner.stop();
 
-  console.log(`\nIssue: #${result.issue.number} — ${result.issue.title}`);
-  console.log(`Ready: ${result.ready ? "YES" : "NO"}`);
+  const readyLabel = result.ready ? c.success("YES") : c.error("NO");
+
+  console.log(`\n${c.bold("Issue:")} #${result.issue.number} — ${result.issue.title}`);
+  console.log(`${c.bold("Ready:")} ${readyLabel}`);
 
   if (result.pr) {
-    console.log(`PR: #${result.pr.number} — ${result.pr.title}`);
+    console.log(`${c.bold("PR:")} #${result.pr.number} — ${result.pr.title}`);
   } else {
-    console.log("PR: none found");
+    console.log(`${c.bold("PR:")} ${c.dim("none found")}`);
   }
 
   if (result.blockers.length > 0) {
-    console.log("\nBlockers:");
-    result.blockers.forEach((b) => console.log(`  - ${b}`));
+    console.log(`\n${c.error("Blockers:")}`);
+    result.blockers.forEach((b) => console.log(`  ${c.error("-")} ${b}`));
   }
 
-  console.log("\nCritique:");
+  console.log(`\n${c.bold("Critique:")}`);
   console.log(result.critique);
 
-  console.log("\nNext steps:");
+  console.log(`\n${c.bold("Next steps:")}`);
   result.nextSteps.forEach((step, i) => {
     console.log(`  ${i + 1}. ${step}`);
   });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,6 +8,7 @@ import { releaseCommand } from "./commands/release";
 import { chatCommand } from "./commands/chat";
 import { auditCommand } from "./commands/audit";
 import { getVersion } from "./utils/getVersion";
+import { printWelcome } from "./utils/ui";
 
 export const USAGE = `cforge-dev — AI-native SDLC orchestrator
 
@@ -25,12 +26,8 @@ Usage:
 export async function main(): Promise<void> {
   const [command, ...args] = process.argv.slice(2);
 
-  if (!command || command === "--help") {
-    console.log(USAGE);
-    process.exit(0);
-  }
-
-  if (command === "--help" || command === "-h") {
+  if (!command || command === "--help" || command === "-h") {
+    printWelcome(getVersion(), "cforge-dev");
     console.log(USAGE);
     process.exit(0);
   }

--- a/src/cli/utils/ui.ts
+++ b/src/cli/utils/ui.ts
@@ -1,0 +1,60 @@
+import chalk from "chalk";
+import ora from "ora";
+import boxen from "boxen";
+
+/** Returns true when NO_COLOR env var is set (https://no-color.org/) */
+function isNoColor(): boolean {
+  return !!process.env.NO_COLOR;
+}
+
+/** Color-coded output helpers */
+export const c = {
+  success: (s: string): string => chalk.green(s),
+  error:   (s: string): string => chalk.red(s),
+  warning: (s: string): string => chalk.yellow(s),
+  info:    (s: string): string => chalk.blue(s),
+  dim:     (s: string): string => chalk.dim(s),
+  bold:    (s: string): string => chalk.bold(s),
+
+  /** Color-coded issue type label: [BUG], [FEATURE], [TASK], [ARCHITECTURE] */
+  issueType: (type: string): string => {
+    switch (type.toUpperCase()) {
+      case "ARCHITECTURE": return chalk.blue(`[${type}]`);
+      case "FEATURE":      return chalk.green(`[${type}]`);
+      case "TASK":         return chalk.yellow(`[${type}]`);
+      case "BUG":          return chalk.red(`[${type}]`);
+      default:             return `[${type}]`;
+    }
+  },
+
+  /** Cost + turns metric, visually distinct from regular status text */
+  metric: (s: string): string => chalk.cyan(s),
+};
+
+/** Create a spinner — silent when not in a TTY or NO_COLOR is set */
+export function createSpinner(text: string) {
+  return ora({
+    text,
+    isSilent: !process.stdout.isTTY || isNoColor(),
+  }).start();
+}
+
+/** Print a branded welcome box (plain-text fallback when NO_COLOR is set) */
+export function printWelcome(version: string, repo: string): void {
+  if (isNoColor()) {
+    console.log(`cforge-dev v${version}  ·  ${repo}`);
+    return;
+  }
+  const content = [
+    chalk.bold.cyan("cforge-dev") + "  " + chalk.dim(`v${version}`),
+    chalk.dim(`${repo}  ·  AI-native SDLC orchestrator`),
+  ].join("\n");
+  console.log(
+    boxen(content, {
+      padding: { top: 0, bottom: 0, left: 1, right: 1 },
+      margin: 1,
+      borderStyle: "round",
+      borderColor: "cyan",
+    })
+  );
+}

--- a/tests/cli/utils/ui.test.ts
+++ b/tests/cli/utils/ui.test.ts
@@ -1,0 +1,117 @@
+import { c, printWelcome } from "../../../src/cli/utils/ui";
+
+describe("c.issueType", () => {
+  it("wraps ARCHITECTURE in brackets", () => {
+    expect(c.issueType("ARCHITECTURE")).toContain("[ARCHITECTURE]");
+  });
+
+  it("wraps FEATURE in brackets", () => {
+    expect(c.issueType("FEATURE")).toContain("[FEATURE]");
+  });
+
+  it("wraps TASK in brackets", () => {
+    expect(c.issueType("TASK")).toContain("[TASK]");
+  });
+
+  it("wraps BUG in brackets", () => {
+    expect(c.issueType("BUG")).toContain("[BUG]");
+  });
+
+  it("wraps unknown types in brackets", () => {
+    expect(c.issueType("CUSTOM")).toContain("[CUSTOM]");
+  });
+});
+
+describe("c color helpers", () => {
+  it("c.success returns string containing input", () => {
+    expect(c.success("ok")).toContain("ok");
+  });
+
+  it("c.error returns string containing input", () => {
+    expect(c.error("fail")).toContain("fail");
+  });
+
+  it("c.warning returns string containing input", () => {
+    expect(c.warning("warn")).toContain("warn");
+  });
+
+  it("c.info returns string containing input", () => {
+    expect(c.info("info")).toContain("info");
+  });
+
+  it("c.dim returns string containing input", () => {
+    expect(c.dim("muted")).toContain("muted");
+  });
+
+  it("c.bold returns string containing input", () => {
+    expect(c.bold("strong")).toContain("strong");
+  });
+
+  it("c.metric returns string containing input", () => {
+    expect(c.metric("$0.0042")).toContain("$0.0042");
+  });
+});
+
+describe("printWelcome", () => {
+  let mockLog: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockLog = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    mockLog.mockRestore();
+  });
+
+  it("outputs cforge-dev branding", () => {
+    printWelcome("1.0.0", "owner/repo");
+    const output = mockLog.mock.calls[0][0] as string;
+    expect(output).toContain("cforge-dev");
+  });
+
+  it("outputs version", () => {
+    printWelcome("2.3.4", "owner/repo");
+    const output = mockLog.mock.calls[0][0] as string;
+    expect(output).toContain("2.3.4");
+  });
+
+  it("outputs repo", () => {
+    printWelcome("1.0.0", "acme/myapp");
+    const output = mockLog.mock.calls[0][0] as string;
+    expect(output).toContain("acme/myapp");
+  });
+});
+
+describe("NO_COLOR=1 support", () => {
+  let mockLog: jest.SpyInstance;
+  let originalNoColor: string | undefined;
+
+  beforeEach(() => {
+    originalNoColor = process.env.NO_COLOR;
+    process.env.NO_COLOR = "1";
+    mockLog = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (originalNoColor === undefined) {
+      delete process.env.NO_COLOR;
+    } else {
+      process.env.NO_COLOR = originalNoColor;
+    }
+    mockLog.mockRestore();
+  });
+
+  it("printWelcome outputs plain text without ANSI codes when NO_COLOR=1", () => {
+    printWelcome("1.0.0", "owner/repo");
+    const output = mockLog.mock.calls[0][0] as string;
+    expect(output).toContain("cforge-dev");
+    expect(output).toContain("1.0.0");
+    expect(output).not.toMatch(/\x1b\[/);
+  });
+
+  it("printWelcome output contains repo when NO_COLOR=1", () => {
+    printWelcome("1.0.0", "owner/repo");
+    const output = mockLog.mock.calls[0][0] as string;
+    expect(output).toContain("owner/repo");
+  });
+});


### PR DESCRIPTION
## Summary
Automated implementation via cforge-dev --auto

Improve CLI visual design to match Claude Code terminal aesthetic

## Issue
Closes #13

## Implementation
All 194 tests pass. Here's what was implemented:

**New file: `src/cli/utils/ui.ts`**
- `c` — color helpers: `success` (green), `error` (red), `warning` (yellow), `info` (blue), `dim`, `bold`, `metric` (cyan for cost/turns)
- `c.issueType(type)` — color-coded labels: `[ARCHITECTURE]` blue, `[FEATURE]` green, `[TASK]` yellow, `[BUG]` red
- `createSpinner(text)` — `ora` spinner, silent when not in a TTY (so tests aren't affected)
- `printWelcome(version, repo)` — `boxen` rounded-border box; falls 

## Cost
Claude session cost: $1.4003 (39 turns)