### PR TITLE
feat: Fix: handle existing remote branch on implement --auto retry

### DIFF
--- a/src/application/use-cases/AutoImplement.ts
+++ b/src/application/use-cases/AutoImplement.ts
@@ -2,6 +2,7 @@ import { execSync } from "child_process";
 import { GitHubClient } from "../../domain/interfaces/GitHubClient";
 import { PromptGenerator } from "../../domain/interfaces/PromptGenerator";
 import { CodeRunner } from "../../domain/interfaces/CodeRunner";
+import { BranchConflictResolver } from "../../domain/interfaces/BranchConflictResolver";
 import { Issue, IssueType } from "../../domain/models/Issue";
 import { ProjectContext } from "../../domain/models/ProjectContext";
 import { AutoImplementResult } from "../../domain/models/AutoImplementResult";
@@ -28,18 +29,21 @@ export class AutoImplement {
   private readonly codeRunner: CodeRunner;
   private readonly testRunner: (dir: string) => Promise<{ passed: boolean; output: string }>;
   private readonly doctrine: SDLCDoctrine;
+  private readonly branchConflictResolver?: BranchConflictResolver;
 
   constructor(
     github: GitHubClient,
     promptGen: PromptGenerator,
     codeRunner: CodeRunner,
     testRunner: (dir: string) => Promise<{ passed: boolean; output: string }>,
+    branchConflictResolver?: BranchConflictResolver,
   ) {
     this.github = github;
     this.promptGen = promptGen;
     this.codeRunner = codeRunner;
     this.testRunner = testRunner;
     this.doctrine = new SDLCDoctrine();
+    this.branchConflictResolver = branchConflictResolver;
   }
 
   async execute(input: AutoImplementInput): Promise<AutoImplementResult> {
@@ -47,10 +51,41 @@ export class AutoImplement {
     const issue = await this.github.getIssue(input.issueNumber);
     this.doctrine.validateIssueForImplementation(issue);
 
-    // Step 2: Generate branch name, create branch
+    // Step 2: Generate branch name, handle existing branch or create new
     const branch = this.buildBranchName(issue);
     this.doctrine.validateBranchName(branch, issue);
-    await this.github.createBranch(branch, "main");
+
+    const exists = await this.github.branchExists(branch);
+    if (exists) {
+      if (!this.branchConflictResolver) {
+        throw new Error(
+          `Branch '${branch}' already exists on remote. Delete it manually or retry with a conflict resolver.`
+        );
+      }
+      const action = await this.branchConflictResolver.resolve(branch);
+      if (action === "abort") {
+        return {
+          issue,
+          branch,
+          success: false,
+          testsPassed: false,
+          cost: 0,
+          turns: 0,
+          claudeOutput: "",
+          stopReason: "aborted",
+          retried: false,
+          error: "Aborted by user: branch already exists, no changes made.",
+          manualStepsRequired: [],
+        };
+      }
+      if (action === "reset") {
+        await this.github.deleteBranch(branch);
+        await this.github.createBranch(branch, "main");
+      }
+      // "continue": use existing branch as-is
+    } else {
+      await this.github.createBranch(branch, "main");
+    }
 
     // Step 3: Generate implementation prompt
     const basePrompt = await this.promptGen.generateImplementationPrompt(issue, input.context);

--- a/src/application/use-cases/ImplementIssue.ts
+++ b/src/application/use-cases/ImplementIssue.ts
@@ -1,5 +1,6 @@
 import { GitHubClient } from "../../domain/interfaces/GitHubClient";
 import { PromptGenerator } from "../../domain/interfaces/PromptGenerator";
+import { BranchConflictResolver } from "../../domain/interfaces/BranchConflictResolver";
 import { Issue, IssueType } from "../../domain/models/Issue";
 import { ProjectContext } from "../../domain/models/ProjectContext";
 import { SDLCDoctrine } from "../../domain/engines/SDLCDoctrine";
@@ -24,11 +25,13 @@ export class ImplementIssue {
   private readonly github: GitHubClient;
   private readonly promptGen: PromptGenerator;
   private readonly doctrine: SDLCDoctrine;
+  private readonly branchConflictResolver?: BranchConflictResolver;
 
-  constructor(github: GitHubClient, promptGen: PromptGenerator) {
+  constructor(github: GitHubClient, promptGen: PromptGenerator, branchConflictResolver?: BranchConflictResolver) {
     this.github = github;
     this.promptGen = promptGen;
     this.doctrine = new SDLCDoctrine();
+    this.branchConflictResolver = branchConflictResolver;
   }
 
   async execute(input: ImplementIssueDto): Promise<ImplementIssueResult> {
@@ -39,7 +42,25 @@ export class ImplementIssue {
     const branch = this.buildBranchName(issue);
     this.doctrine.validateBranchName(branch, issue);
 
-    await this.github.createBranch(branch, "main");
+    const exists = await this.github.branchExists(branch);
+    if (exists) {
+      if (!this.branchConflictResolver) {
+        throw new Error(
+          `Branch '${branch}' already exists on remote. Delete it manually or retry with a conflict resolver.`
+        );
+      }
+      const action = await this.branchConflictResolver.resolve(branch);
+      if (action === "abort") {
+        throw new Error("Aborted: branch already exists, no changes made.");
+      }
+      if (action === "reset") {
+        await this.github.deleteBranch(branch);
+        await this.github.createBranch(branch, "main");
+      }
+      // "continue": use existing branch as-is
+    } else {
+      await this.github.createBranch(branch, "main");
+    }
 
     const prompt = await this.promptGen.generateImplementationPrompt(issue, input.context);
 

--- a/src/cli/commands/implement.ts
+++ b/src/cli/commands/implement.ts
@@ -7,6 +7,7 @@ import { AutoImplement } from "../../application/use-cases/AutoImplement";
 import { loadContext } from "../utils/loadContext";
 import { validatePresence, validateNumericIssueNumber, USAGE_IMPLEMENT } from "../validation";
 import { c, createSpinner } from "../utils/ui";
+import { StdinBranchConflictResolver } from "../utils/StdinBranchConflictResolver";
 
 export async function implementCommand(issueNumberStr: string, flags: string[] = []): Promise<void> {
   if (issueNumberStr === "--help" || flags.includes("--help")) {
@@ -42,7 +43,8 @@ async function runManualImplement(issueNumber: number): Promise<void> {
   const context = loadContext();
   const gh = new OctokitGitHubClient(context.repoOwner, context.repoName);
   const promptGen = new CForgePromptGenerator();
-  const impl = new ImplementIssue(gh, promptGen);
+  const resolver = new StdinBranchConflictResolver();
+  const impl = new ImplementIssue(gh, promptGen, resolver);
 
   const spinner = createSpinner("Fetching issue…");
   const result = await impl.execute({ issueNumber, context });
@@ -88,7 +90,8 @@ async function runAutoImplement(issueNumber: number, maxBudgetUsd?: number): Pro
     }
   };
 
-  const auto = new AutoImplement(gh, promptGen, codeRunner, testRunner);
+  const resolver = new StdinBranchConflictResolver();
+  const auto = new AutoImplement(gh, promptGen, codeRunner, testRunner, resolver);
 
   console.log("");
   console.log(c.bold("══════════════════════════════════════"));
@@ -120,6 +123,8 @@ async function runAutoImplement(issueNumber: number, maxBudgetUsd?: number): Pro
     console.log(c.success("DONE — Review PR and merge when ready"));
     console.log(c.dim(`cforge-dev verify ${issueNumber}`));
     console.log(c.bold("══════════════════════════════════════"));
+  } else if (result.stopReason === "aborted") {
+    console.log(`  ${c.warning("\u2212")} ${result.error}`);
   } else {
     console.log(`  ${c.error("\u2717")} ${result.error}`);
     if (result.retried) {

--- a/src/cli/utils/StdinBranchConflictResolver.ts
+++ b/src/cli/utils/StdinBranchConflictResolver.ts
@@ -1,0 +1,38 @@
+import * as readline from "readline";
+import { BranchConflictResolver } from "../../domain/interfaces/BranchConflictResolver";
+import { BranchConflictAction } from "../../domain/models/BranchConflictAction";
+import { c } from "./ui";
+
+export class StdinBranchConflictResolver implements BranchConflictResolver {
+  async resolve(branch: string): Promise<BranchConflictAction> {
+    console.log(`\n${c.warning(`Branch '${branch}' already exists on remote.`)}`);
+    console.log(`  ${c.bold("(c)")} Continue — check out the existing branch and resume`);
+    console.log(`  ${c.bold("(r)")} Reset    — delete the existing branch and start fresh`);
+    console.log(`  ${c.bold("(a)")} Abort    — exit without making any changes`);
+
+    return new Promise((resolve) => {
+      const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+      const ask = () => {
+        rl.question(`\n${c.dim("Your choice [c/r/a]: ")}`, (answer) => {
+          const choice = answer.trim().toLowerCase();
+          if (choice === "c" || choice === "continue") {
+            rl.close();
+            resolve("continue");
+          } else if (choice === "r" || choice === "reset") {
+            rl.close();
+            resolve("reset");
+          } else if (choice === "a" || choice === "abort") {
+            rl.close();
+            resolve("abort");
+          } else {
+            console.log(c.error("  Please enter c, r, or a."));
+            ask();
+          }
+        });
+      };
+
+      ask();
+    });
+  }
+}

--- a/src/domain/interfaces/BranchConflictResolver.ts
+++ b/src/domain/interfaces/BranchConflictResolver.ts
@@ -1,0 +1,5 @@
+import { BranchConflictAction } from "../models/BranchConflictAction";
+
+export interface BranchConflictResolver {
+  resolve(branch: string): Promise<BranchConflictAction>;
+}

--- a/src/domain/interfaces/GitHubClient.ts
+++ b/src/domain/interfaces/GitHubClient.ts
@@ -8,6 +8,8 @@ export interface GitHubClient {
   getIssue(number: number): Promise<Issue>;
   listIssues(milestoneId?: number): Promise<Issue[]>;
   createBranch(name: string, fromBranch: string): Promise<void>;
+  branchExists(name: string): Promise<boolean>;
+  deleteBranch(name: string): Promise<void>;
   createPullRequest(title: string, body: string, branch: string, base: string): Promise<PullRequest>;
   getPullRequest(number: number): Promise<PullRequest>;
   listOpenPullRequests(): Promise<PullRequest[]>;

--- a/src/domain/models/BranchConflictAction.ts
+++ b/src/domain/models/BranchConflictAction.ts
@@ -1,0 +1,1 @@
+export type BranchConflictAction = "continue" | "reset" | "abort";

--- a/src/infrastructure/github/OctokitGitHubClient.ts
+++ b/src/infrastructure/github/OctokitGitHubClient.ts
@@ -94,6 +94,30 @@ export class OctokitGitHubClient implements GitHubClient {
     });
   }
 
+  async branchExists(name: string): Promise<boolean> {
+    try {
+      await this.octokit.git.getRef({
+        owner: this.owner,
+        repo: this.repo,
+        ref: `heads/${name}`,
+      });
+      return true;
+    } catch (err: unknown) {
+      if ((err as { status?: number }).status === 404) {
+        return false;
+      }
+      throw err;
+    }
+  }
+
+  async deleteBranch(name: string): Promise<void> {
+    await this.octokit.git.deleteRef({
+      owner: this.owner,
+      repo: this.repo,
+      ref: `heads/${name}`,
+    });
+  }
+
   async createPullRequest(title: string, body: string, branch: string, base: string): Promise<PullRequest> {
     const { data } = await this.octokit.pulls.create({
       owner: this.owner,

--- a/tests/application/AutoImplement.test.ts
+++ b/tests/application/AutoImplement.test.ts
@@ -4,10 +4,12 @@ jest.mock("child_process", () => ({
 
 import { AutoImplement } from "../../src/application/use-cases/AutoImplement";
 import { GitHubClient } from "../../src/domain/interfaces/GitHubClient";
+import { BranchConflictResolver } from "../../src/domain/interfaces/BranchConflictResolver";
 import { PromptGenerator } from "../../src/domain/interfaces/PromptGenerator";
 import { CodeRunner, RunResult } from "../../src/domain/interfaces/CodeRunner";
 import { IssueType, Issue } from "../../src/domain/models/Issue";
 import { ProjectContext } from "../../src/domain/models/ProjectContext";
+import { BranchConflictAction } from "../../src/domain/models/BranchConflictAction";
 
 const mockContext: ProjectContext = {
   repoOwner: "test-owner",
@@ -42,13 +44,15 @@ function makeRunResult(overrides: Partial<RunResult> = {}): RunResult {
   };
 }
 
-function mockGitHubClient(issue: Issue): GitHubClient {
+function mockGitHubClient(issue: Issue, branchAlreadyExists = false): GitHubClient {
   return {
     createMilestone: jest.fn(),
     createIssue: jest.fn(),
     getIssue: jest.fn().mockResolvedValue(issue),
     listIssues: jest.fn(),
     createBranch: jest.fn(),
+    branchExists: jest.fn().mockResolvedValue(branchAlreadyExists),
+    deleteBranch: jest.fn().mockResolvedValue(undefined),
     createPullRequest: jest.fn().mockResolvedValue({
       number: 100,
       title: "feat: add login",
@@ -79,6 +83,12 @@ function mockCodeRunner(result: RunResult): CodeRunner {
 
 function mockTestRunner(passes: boolean): (dir: string) => Promise<{ passed: boolean; output: string }> {
   return jest.fn().mockResolvedValue({ passed: passes, output: passes ? "All tests pass" : "FAIL: 2 tests failed\nExpected X got Y" });
+}
+
+function mockResolver(action: BranchConflictAction): BranchConflictResolver {
+  return {
+    resolve: jest.fn().mockResolvedValue(action),
+  };
 }
 
 describe("AutoImplement", () => {
@@ -257,5 +267,73 @@ describe("AutoImplement", () => {
     const result = await auto.execute({ issueNumber: 42, context: mockContext });
 
     expect(result.retried).toBe(false);
+  });
+
+  // Branch conflict scenarios
+
+  it("branch already exists, no resolver → throws with branch-exists error", async () => {
+    const issue = makeIssue();
+    const gh = mockGitHubClient(issue, true);
+    const prompt = mockPromptGenerator();
+    const runner = mockCodeRunner(makeRunResult());
+    const testRunner = mockTestRunner(true);
+    const auto = new AutoImplement(gh, prompt, runner, testRunner);
+
+    await expect(auto.execute({ issueNumber: 42, context: mockContext })).rejects.toThrow(
+      "already exists"
+    );
+    expect(runner.run).not.toHaveBeenCalled();
+    expect(gh.createBranch).not.toHaveBeenCalled();
+  });
+
+  it("branch already exists, user chooses continue → createBranch NOT called, pipeline proceeds", async () => {
+    const issue = makeIssue();
+    const gh = mockGitHubClient(issue, true);
+    const prompt = mockPromptGenerator();
+    const runner = mockCodeRunner(makeRunResult());
+    const testRunner = mockTestRunner(true);
+    const resolver = mockResolver("continue");
+    const auto = new AutoImplement(gh, prompt, runner, testRunner, resolver);
+
+    const result = await auto.execute({ issueNumber: 42, context: mockContext });
+
+    expect(result.success).toBe(true);
+    expect(gh.createBranch).not.toHaveBeenCalled();
+    expect(gh.deleteBranch).not.toHaveBeenCalled();
+    expect(resolver.resolve).toHaveBeenCalledWith("feat/add-login");
+  });
+
+  it("branch already exists, user chooses reset → deleteBranch then createBranch called", async () => {
+    const issue = makeIssue();
+    const gh = mockGitHubClient(issue, true);
+    const prompt = mockPromptGenerator();
+    const runner = mockCodeRunner(makeRunResult());
+    const testRunner = mockTestRunner(true);
+    const resolver = mockResolver("reset");
+    const auto = new AutoImplement(gh, prompt, runner, testRunner, resolver);
+
+    await auto.execute({ issueNumber: 42, context: mockContext });
+
+    expect(gh.deleteBranch).toHaveBeenCalledWith("feat/add-login");
+    expect(gh.createBranch).toHaveBeenCalledWith("feat/add-login", "main");
+  });
+
+  it("branch already exists, user chooses abort → success false, stopReason aborted, no branch changes", async () => {
+    const issue = makeIssue();
+    const gh = mockGitHubClient(issue, true);
+    const prompt = mockPromptGenerator();
+    const runner = mockCodeRunner(makeRunResult());
+    const testRunner = mockTestRunner(true);
+    const resolver = mockResolver("abort");
+    const auto = new AutoImplement(gh, prompt, runner, testRunner, resolver);
+
+    const result = await auto.execute({ issueNumber: 42, context: mockContext });
+
+    expect(result.success).toBe(false);
+    expect(result.stopReason).toBe("aborted");
+    expect(result.error).toContain("Aborted");
+    expect(gh.createBranch).not.toHaveBeenCalled();
+    expect(gh.deleteBranch).not.toHaveBeenCalled();
+    expect(runner.run).not.toHaveBeenCalled();
   });
 });

--- a/tests/application/CreateRelease.test.ts
+++ b/tests/application/CreateRelease.test.ts
@@ -36,7 +36,9 @@ function mockGitHubClient(issues: Issue[]): GitHubClient {
     getPullRequest: jest.fn(),
     listOpenPullRequests: jest.fn(),
     closeIssue: jest.fn(),
-    createRelease: jest.fn().mockResolvedValue(undefined),
+    createRelease: jest.fn(),
+    branchExists: jest.fn().mockResolvedValue(false),
+    deleteBranch: jest.fn().mockResolvedValue(undefined),
   };
 }
 

--- a/tests/application/ImplementIssue.test.ts
+++ b/tests/application/ImplementIssue.test.ts
@@ -1,8 +1,10 @@
 import { ImplementIssue } from "../../src/application/use-cases/ImplementIssue";
 import { GitHubClient } from "../../src/domain/interfaces/GitHubClient";
+import { BranchConflictResolver } from "../../src/domain/interfaces/BranchConflictResolver";
 import { PromptGenerator } from "../../src/domain/interfaces/PromptGenerator";
 import { IssueType, Issue } from "../../src/domain/models/Issue";
 import { ProjectContext } from "../../src/domain/models/ProjectContext";
+import { BranchConflictAction } from "../../src/domain/models/BranchConflictAction";
 
 const mockContext: ProjectContext = {
   repoOwner: "test-owner",
@@ -26,13 +28,15 @@ function makeIssue(overrides: Partial<Issue> = {}): Issue {
   };
 }
 
-function mockGitHubClient(issue: Issue): GitHubClient {
+function mockGitHubClient(issue: Issue, branchAlreadyExists = false): GitHubClient {
   return {
     createMilestone: jest.fn(),
     createIssue: jest.fn(),
     getIssue: jest.fn().mockResolvedValue(issue),
     listIssues: jest.fn(),
     createBranch: jest.fn().mockResolvedValue(undefined),
+    branchExists: jest.fn().mockResolvedValue(branchAlreadyExists),
+    deleteBranch: jest.fn().mockResolvedValue(undefined),
     createPullRequest: jest.fn(),
     getPullRequest: jest.fn(),
     listOpenPullRequests: jest.fn(),
@@ -45,6 +49,12 @@ function mockPromptGenerator(): PromptGenerator {
   return {
     generateImplementationPrompt: jest.fn().mockResolvedValue("Generated Claude Code prompt for issue #42"),
     generatePlanningPrompt: jest.fn(),
+  };
+}
+
+function mockResolver(action: BranchConflictAction): BranchConflictResolver {
+  return {
+    resolve: jest.fn().mockResolvedValue(action),
   };
 }
 
@@ -170,5 +180,63 @@ describe("ImplementIssue", () => {
       expect.any(String),
       "main"
     );
+  });
+
+  // Branch conflict scenarios
+
+  it("branch already exists, no resolver → throws with branch-exists error", async () => {
+    const issue = makeIssue();
+    const gh = mockGitHubClient(issue, true);
+    const prompt = mockPromptGenerator();
+    const impl = new ImplementIssue(gh, prompt);
+
+    await expect(impl.execute({ issueNumber: 42, context: mockContext })).rejects.toThrow(
+      "already exists"
+    );
+    expect(gh.createBranch).not.toHaveBeenCalled();
+    expect(gh.deleteBranch).not.toHaveBeenCalled();
+  });
+
+  it("branch already exists, user chooses continue → createBranch NOT called, returns result", async () => {
+    const issue = makeIssue();
+    const gh = mockGitHubClient(issue, true);
+    const prompt = mockPromptGenerator();
+    const resolver = mockResolver("continue");
+    const impl = new ImplementIssue(gh, prompt, resolver);
+
+    const result = await impl.execute({ issueNumber: 42, context: mockContext });
+
+    expect(result.branch).toBe("feat/add-user-authentication");
+    expect(gh.createBranch).not.toHaveBeenCalled();
+    expect(gh.deleteBranch).not.toHaveBeenCalled();
+    expect(resolver.resolve).toHaveBeenCalledWith("feat/add-user-authentication");
+  });
+
+  it("branch already exists, user chooses reset → deleteBranch then createBranch called", async () => {
+    const issue = makeIssue();
+    const gh = mockGitHubClient(issue, true);
+    const prompt = mockPromptGenerator();
+    const resolver = mockResolver("reset");
+    const impl = new ImplementIssue(gh, prompt, resolver);
+
+    const result = await impl.execute({ issueNumber: 42, context: mockContext });
+
+    expect(result.branch).toBe("feat/add-user-authentication");
+    expect(gh.deleteBranch).toHaveBeenCalledWith("feat/add-user-authentication");
+    expect(gh.createBranch).toHaveBeenCalledWith("feat/add-user-authentication", "main");
+  });
+
+  it("branch already exists, user chooses abort → throws abort error, no branch changes", async () => {
+    const issue = makeIssue();
+    const gh = mockGitHubClient(issue, true);
+    const prompt = mockPromptGenerator();
+    const resolver = mockResolver("abort");
+    const impl = new ImplementIssue(gh, prompt, resolver);
+
+    await expect(impl.execute({ issueNumber: 42, context: mockContext })).rejects.toThrow(
+      "Aborted"
+    );
+    expect(gh.createBranch).not.toHaveBeenCalled();
+    expect(gh.deleteBranch).not.toHaveBeenCalled();
   });
 });

--- a/tests/application/PlanSprint.test.ts
+++ b/tests/application/PlanSprint.test.ts
@@ -61,6 +61,8 @@ function mockGitHubClient(): GitHubClient {
     listOpenPullRequests: jest.fn(),
     closeIssue: jest.fn(),
     createRelease: jest.fn(),
+    branchExists: jest.fn().mockResolvedValue(false),
+    deleteBranch: jest.fn().mockResolvedValue(undefined),
   };
 }
 

--- a/tests/application/RepoStateLoader.test.ts
+++ b/tests/application/RepoStateLoader.test.ts
@@ -26,6 +26,8 @@ function mockGitHubClient(issues: Issue[]): GitHubClient {
     listOpenPullRequests: jest.fn().mockResolvedValue([]),
     closeIssue: jest.fn(),
     createRelease: jest.fn(),
+    branchExists: jest.fn().mockResolvedValue(false),
+    deleteBranch: jest.fn().mockResolvedValue(undefined),
   };
 }
 

--- a/tests/application/VerifyIssue.test.ts
+++ b/tests/application/VerifyIssue.test.ts
@@ -53,6 +53,8 @@ function mockGitHubClient(issue: Issue, prs: PullRequest[]): GitHubClient {
     listOpenPullRequests: jest.fn().mockResolvedValue(prs),
     closeIssue: jest.fn(),
     createRelease: jest.fn(),
+    branchExists: jest.fn().mockResolvedValue(false),
+    deleteBranch: jest.fn().mockResolvedValue(undefined),
   };
 }
 

--- a/tests/infrastructure/OctokitGitHubClient.test.ts
+++ b/tests/infrastructure/OctokitGitHubClient.test.ts
@@ -18,6 +18,7 @@ const mockOctokit = {
   git: {
     getRef: jest.fn(),
     createRef: jest.fn(),
+    deleteRef: jest.fn(),
   },
   pulls: {
     create: jest.fn(),
@@ -252,6 +253,49 @@ describe("OctokitGitHubClient", () => {
       repo: "test-repo",
       issue_number: 5,
       state: "closed",
+    });
+  });
+
+  it("branchExists returns true when branch ref exists", async () => {
+    mockOctokit.git.getRef.mockResolvedValueOnce({
+      data: { object: { sha: "abc123" } },
+    });
+
+    const result = await client.branchExists("feat/some-feature");
+
+    expect(result).toBe(true);
+    expect(mockOctokit.git.getRef).toHaveBeenCalledWith({
+      owner: "test-owner",
+      repo: "test-repo",
+      ref: "heads/feat/some-feature",
+    });
+  });
+
+  it("branchExists returns false when branch returns 404", async () => {
+    const err = Object.assign(new Error("Not Found"), { status: 404 });
+    mockOctokit.git.getRef.mockRejectedValueOnce(err);
+
+    const result = await client.branchExists("feat/missing-branch");
+
+    expect(result).toBe(false);
+  });
+
+  it("branchExists rethrows non-404 errors", async () => {
+    const err = Object.assign(new Error("Forbidden"), { status: 403 });
+    mockOctokit.git.getRef.mockRejectedValueOnce(err);
+
+    await expect(client.branchExists("feat/some-branch")).rejects.toThrow("Forbidden");
+  });
+
+  it("deleteBranch calls deleteRef with correct params", async () => {
+    mockOctokit.git.deleteRef.mockResolvedValueOnce({});
+
+    await client.deleteBranch("feat/old-branch");
+
+    expect(mockOctokit.git.deleteRef).toHaveBeenCalledWith({
+      owner: "test-owner",
+      repo: "test-repo",
+      ref: "heads/feat/old-branch",
     });
   });
 


### PR DESCRIPTION
## Summary
Automated implementation via cforge-dev --auto

Fix: handle existing remote branch on implement --auto retry

## Issue
Closes #29

## Implementation
All 206 tests pass and the latest commit `b28952f` already has the implementation. The tests were already fixed — there's nothing to do here. The test output provided in the prompt was empty (just showed the test command being run with no failures listed), and running the tests now shows all 18 test suites passing with 206 tests.

The branch is clean, all tests pass, and the commit is already in place.

## Cost
Claude session cost: $0.0313 (4 turns)